### PR TITLE
Fix typo on <ul> closing tag

### DIFF
--- a/src/blog/2020-05-06-using-nunjucks-if-expressions-to-create-an-active-navigation-state-in-11ty.md
+++ b/src/blog/2020-05-06-using-nunjucks-if-expressions-to-create-an-active-navigation-state-in-11ty.md
@@ -62,7 +62,7 @@ Our navigation has been abstracted out to be used in our `header.njk` file. Let'
         <li><a class="nav__item" href="/work-with-bryan">Work</a></li>
         <li><a class="nav__item" href="/about">About</a></li>
         <li><a class="nav__item" href="/contact">Contact</a></li>
-    </div>
+    </ul>
 </nav>
 {% endhighlight %}
 


### PR DESCRIPTION
Hey, Bryan. I came across a typo while reading [Using Nunjucks 'If Expressions' in 11ty to create a simple active navigation state](https://bryanlrobinson.com/blog/using-nunjucks-if-expressions-to-create-an-active-navigation-state-in-11ty/). 

The `<ul>` element is closed with a `</div>` rather than the expected `</ul>` closing tag. [Lines 60-65](https://github.com/brob/bryanlrobinson.com/blame/master/src/blog/2020-05-06-using-nunjucks-if-expressions-to-create-an-active-navigation-state-in-11ty.md#L60-L65). 

I added the correct unordered list closing tag to fix the typo. Thanks! @brob 
